### PR TITLE
fix RadixLogic.getAllEntitiesOfTypeWithinDistance only detecting entities of class or superclass

### DIFF
--- a/src/main/java/radixcore/util/RadixLogic.java
+++ b/src/main/java/radixcore/util/RadixLogic.java
@@ -484,7 +484,7 @@ public final class RadixLogic
 		
 		for (Entity entity : entitiesAroundMe)
 		{
-			if (entity.getClass().isAssignableFrom(clazz))
+			if (clazz.isInstance(entity))
 			{
 				returnList.add(entity);
 			}


### PR DESCRIPTION
In L487, the if-statement

```
if (entity.getClass().isAssignableFrom(clazz))
```

is used to determine whether or not an entity is supposed to be added to the detection list or not. According to the javadoc of `Class#isAssignableFrom(Class)`, it determines whether the underlying class "is either the same as, or is a superclass or superinterface of, the class or interface represented by the specified Class parameter" (https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#isAssignableFrom-java.lang.Class-). I do not think this was as it was intended to be because `getAllEntitiesOfTypeWithinDistance` will only return entities of the said type (or superclasses of it).

Example:
If this method is called with `clazz = mca.entity.EntityHuman.class`, it will detect all entities within range and of type `EntityHuman`, `EntityVillager` and `EntityVillager`'s superclasses.

In case the intended behaviour was to only detect entities of that type without sub- or superclasses, replace L487 with the following:

```
if (clazz.equals(entity.getClass()))
```
